### PR TITLE
Updated workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,10 +5,25 @@ on:
     branches:
       - main
 
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +44,12 @@ jobs:
 
   format:
     name: Format
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +70,12 @@ jobs:
 
   type:
     name: TypeScript
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +96,12 @@ jobs:
 
   build:
     name: Build
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,28 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:
     name: Release
 
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'changeset-release/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
-
     outputs:
       tag: ${{ steps.release.outputs.tag }}
 
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'changeset-release/main')
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,11 +56,12 @@ jobs:
   publish:
     name: Publish
 
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
 
-    needs: release
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -5,17 +5,26 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   version:
     name: Create Release Pull Request
 
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
       contents: write
 
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

<!-- Add a brief description. -->
Updated workflows.

- explicit permissions
- canceled duplicate workflow run
- set timeout
- set default shell to `bash`


## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
reference: https://gihyo.jp/article/2024/10/good-practices-for-github-actions